### PR TITLE
Refactor stacksrule

### DIFF
--- a/TRex2-lib/src/Common/Funs.cc
+++ b/TRex2-lib/src/Common/Funs.cc
@@ -19,6 +19,7 @@
 //
 
 #include "Funs.h"
+#include <algorithm>
 
 using namespace std;
 
@@ -497,6 +498,26 @@ int getLastValidElement(vector<PubPkt*>& column, int columnSize,
   if (column[maxValue]->getTimeStamp() < maxTimeStamp)
     return maxValue;
   return minValue;
+}
+
+class CompareTS {
+public:
+  bool operator()(const TimeMs& a, PubPkt* b) { return a < b->getTimeStamp(); }
+  bool operator()(PubPkt* a, const TimeMs& b) { return a->getTimeStamp() < b; }
+  bool operator()(const TimeMs& a, const TimeMs& b) { return a < b; }
+  bool operator()(PubPkt* a, PubPkt* b) {
+    return a->getTimeStamp() < b->getTimeStamp();
+  }
+};
+
+vector<PubPkt*>::iterator getBeginPacket(vector<PubPkt*>& column,
+                                         TimeMs minTime) {
+  return std::upper_bound(column.begin(), column.end(), minTime, CompareTS());
+}
+
+vector<PubPkt*>::iterator getEndPacket(vector<PubPkt*>& column,
+                                       TimeMs maxTime) {
+  return std::lower_bound(column.begin(), column.end(), maxTime, CompareTS());
 }
 
 int deleteInvalidElements(vector<PubPkt*>& column, int columnSize,

--- a/TRex2-lib/src/Common/Funs.h
+++ b/TRex2-lib/src/Common/Funs.h
@@ -104,21 +104,49 @@ Parameter* dupParameter(Parameter* param);
  * value greater than minTimeStamp.
  * Returns -1 if such an element cannot be found.
  * The search is performed in logarithmic time, using a binary search.
+ *
+ * @deprecated use
+ *     `vector<PubPkt*>::iterator getBeginPacket(
+ *          vector<PubPkt*>& column, TimeMs minTime
+ *     )`
  */
 int getFirstValidElement(std::vector<PubPkt*>& column, int columnSize,
                          TimeMs minTimeStamp);
+
+/**
+ * Returns an iterator pointing to the first element in the given column having
+ * a timestamp greater than minTime, or to the end of the vector if such an
+ * element cannot be found.
+ * The search is performed in logarithmic time, using a binary search.
+ */
+vector<PubPkt*>::iterator getBeginPacket(vector<PubPkt*>& column,
+                                         TimeMs minTime);
 
 /**
  * Returns the id of the last element in the given column having a
  * value smaller than maxTimeStamp and an index greater than minIndex.
  * Returns -1 if such an element cannot be found.
  * The search is performed in logarithmic time, using a binary search.
+ *
+ * @deprecated use
+ *     `vector<PubPkt*>::iterator getEndPacket(
+ *          vector<PubPkt*>& column, TimeMs maxTime
+ *     )`
  */
 int getLastValidElement(std::vector<PubPkt*>& column, int columnSize,
                         TimeMs maxTimeStamp, int minIndex);
+/**
+ * Returns an iterator pointing to the element after the last one in the given
+ * column having a timestamp smaller than maxTime, or to the end of the vector
+ * if such an element cannot be found.
+ * The search is performed in logarithmic time, using a binary search.
+ */
+vector<PubPkt*>::iterator getEndPacket(vector<PubPkt*>& column, TimeMs maxTime);
 
 /**
  * Returns the new size of the column.
+ *
+ * @deprecated this function is quite useless and confusing
  */
 int deleteInvalidElements(std::vector<PubPkt*>& column, int columnSize,
                           TimeMs minTimeStamp);

--- a/TRex2-lib/src/Engine/CompositeEventGenerator.cc
+++ b/TRex2-lib/src/Engine/CompositeEventGenerator.cc
@@ -30,10 +30,10 @@ CompositeEventGenerator::CompositeEventGenerator(
 CompositeEventGenerator::~CompositeEventGenerator() { delete ceTemplate; }
 
 PubPkt* CompositeEventGenerator::generateCompositeEvent(
-    PartialEvent* partialEvent, map<int, Aggregate*>& aggregates,
-    int aggsSize[MAX_RULE_FIELDS], map<int, vector<PubPkt*>>& receivedPkts,
-    map<int, vector<PubPkt*>>& receivedAggs,
-    map<int, set<CPUParameter*>>& aggregateParameters) {
+    PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedAggs,
+    std::map<int, std::vector<CPUParameter>>& aggregateParameters) {
   int eventType = ceTemplate->getEventType();
   int attributesNum = ceTemplate->getAttributesNum();
   int staticAttributesNum = ceTemplate->getStaticAttributesNum();
@@ -65,15 +65,16 @@ PubPkt* CompositeEventGenerator::generateCompositeEvent(
   }
   PubPkt* result =
       new PubPkt(eventType, attributes, attributesNum + staticAttributesNum);
-  result->setTime(partialEvent->indexes[0]->getTimeStamp());
+  result->setTime(partialEvent.indexes[0]->getTimeStamp());
   return result;
 }
 
 inline int CompositeEventGenerator::computeIntValue(
-    PartialEvent* partialEvent, map<int, Aggregate*>& aggregates,
-    int aggsSize[MAX_RULE_FIELDS], map<int, vector<PubPkt*>>& receivedPkts,
-    map<int, vector<PubPkt*>>& receivedAggs,
-    map<int, set<CPUParameter*>>& aggregateParameters, OpTree* opTree) {
+    PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedAggs,
+    std::map<int, std::vector<CPUParameter>>& aggregateParameters,
+    OpTree* opTree) {
   OpTreeType type = opTree->getType();
   if (type == LEAF) {
     OpValueReference* reference = opTree->getValueReference();
@@ -92,7 +93,7 @@ inline int CompositeEventGenerator::computeIntValue(
     int index = pktReference->getIndex();
     bool refersToAgg = pktReference->refersToAgg();
     if (!refersToAgg) {
-      PubPkt* pkt = partialEvent->indexes[index];
+      PubPkt* pkt = partialEvent.indexes[index];
       int attrIndex;
       ValType type;
       if (pkt->getAttributeIndexAndType(pktReference->getName(), attrIndex,
@@ -131,10 +132,11 @@ inline int CompositeEventGenerator::computeIntValue(
 }
 
 inline float CompositeEventGenerator::computeFloatValue(
-    PartialEvent* partialEvent, map<int, Aggregate*>& aggregates,
-    int aggsSize[MAX_RULE_FIELDS], map<int, vector<PubPkt*>>& receivedPkts,
-    map<int, vector<PubPkt*>>& receivedAggs,
-    map<int, set<CPUParameter*>>& aggregateParameters, OpTree* opTree) {
+    PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedAggs,
+    std::map<int, std::vector<CPUParameter>>& aggregateParameters,
+    OpTree* opTree) {
   OpTreeType type = opTree->getType();
   if (type == LEAF) {
     OpValueReference* reference = opTree->getValueReference();
@@ -154,7 +156,7 @@ inline float CompositeEventGenerator::computeFloatValue(
     int index = pktReference->getIndex();
     bool refersToAgg = pktReference->refersToAgg();
     if (!refersToAgg) {
-      PubPkt* pkt = partialEvent->indexes[index];
+      PubPkt* pkt = partialEvent.indexes[index];
       int attrIndex;
       ValType type;
       if (pkt->getAttributeIndexAndType(pktReference->getName(), attrIndex,
@@ -203,10 +205,11 @@ inline float CompositeEventGenerator::computeFloatValue(
 }
 
 inline bool CompositeEventGenerator::computeBoolValue(
-    PartialEvent* partialEvent, map<int, Aggregate*>& aggregates,
-    int aggsSize[MAX_RULE_FIELDS], map<int, vector<PubPkt*>>& receivedPkts,
-    map<int, vector<PubPkt*>>& receivedAggs,
-    map<int, set<CPUParameter*>>& aggregateParameters, OpTree* opTree) {
+    PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedAggs,
+    std::map<int, std::vector<CPUParameter>>& aggregateParameters,
+    OpTree* opTree) {
   OpTreeType type = opTree->getType();
   if (type == LEAF) {
     OpValueReference* reference = opTree->getValueReference();
@@ -226,7 +229,7 @@ inline bool CompositeEventGenerator::computeBoolValue(
     int index = pktReference->getIndex();
     bool refersToAgg = pktReference->refersToAgg();
     if (!refersToAgg) {
-      PubPkt* pkt = partialEvent->indexes[index];
+      PubPkt* pkt = partialEvent.indexes[index];
       int attrIndex;
       ValType type;
       if (pkt->getAttributeIndexAndType(pktReference->getName(), attrIndex,
@@ -256,11 +259,11 @@ inline bool CompositeEventGenerator::computeBoolValue(
 }
 
 inline void CompositeEventGenerator::computeStringValue(
-    PartialEvent* partialEvent, map<int, Aggregate*>& aggregates,
-    int aggsSize[MAX_RULE_FIELDS], map<int, vector<PubPkt*>>& receivedPkts,
-    map<int, vector<PubPkt*>>& receivedAggs,
-    map<int, set<CPUParameter*>>& aggregateParameters, OpTree* opTree,
-    char* result) {
+    PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedAggs,
+    std::map<int, std::vector<CPUParameter>>& aggregateParameters,
+    OpTree* opTree, char* result) {
   // No operator is defined for strings: type can only be LEAF
   OpValueReference* reference = opTree->getValueReference();
   RulePktValueReference* pktReference =
@@ -274,7 +277,7 @@ inline void CompositeEventGenerator::computeStringValue(
   int index = pktReference->getIndex();
   bool refersToAgg = pktReference->refersToAgg();
   if (!refersToAgg) {
-    PubPkt* pkt = partialEvent->indexes[index];
+    PubPkt* pkt = partialEvent.indexes[index];
     int attrIndex;
     ValType type;
     strcpy(result, "");
@@ -288,17 +291,17 @@ inline void CompositeEventGenerator::computeStringValue(
 }
 
 inline float CompositeEventGenerator::computeAggregate(
-    int index, PartialEvent* partialEvent, map<int, Aggregate*>& aggregates,
-    int aggsSize[MAX_RULE_FIELDS], map<int, vector<PubPkt*>>& receivedPkts,
-    map<int, vector<PubPkt*>>& receivedAggs,
-    map<int, set<CPUParameter*>>& aggregateParameters) {
-  Aggregate* agg = aggregates[index];
-  TimeMs maxTS = partialEvent->indexes[agg->upperId]->getTimeStamp();
+    int index, PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedAggs,
+    std::map<int, std::vector<CPUParameter>>& aggregateParameters) {
+  Aggregate& agg = aggregates[index];
+  TimeMs maxTS = partialEvent.indexes[agg.upperId]->getTimeStamp();
   TimeMs minTS = 0;
-  if (agg->lowerId < 0) {
-    minTS = maxTS - agg->lowerTime;
+  if (agg.lowerId < 0) {
+    minTS = maxTS - agg.lowerTime;
   } else {
-    minTS = partialEvent->indexes[agg->lowerId]->getTimeStamp();
+    minTS = partialEvent.indexes[agg.lowerId]->getTimeStamp();
   }
   int index1 =
       getFirstValidElement(receivedAggs[index], aggsSize[index], minTS);
@@ -308,8 +311,8 @@ inline float CompositeEventGenerator::computeAggregate(
       getLastValidElement(receivedAggs[index], aggsSize[index], maxTS, index1);
   if (index2 < 0)
     index2 = index1;
-  AggregateFun fun = agg->fun;
-  char* name = agg->name;
+  AggregateFun fun = agg.fun;
+  char* name = agg.name;
   float sum = 0;
   int count = 0;
   float min = 0;
@@ -318,7 +321,7 @@ inline float CompositeEventGenerator::computeAggregate(
   ValType type;
   bool checkParams = false;
   bool firstValue = true;
-  map<int, set<CPUParameter*>>::iterator paramIt =
+  map<int, vector<CPUParameter>>::iterator paramIt =
       aggregateParameters.find(index);
   if (paramIt != aggregateParameters.end())
     checkParams = true;
@@ -371,13 +374,12 @@ inline float CompositeEventGenerator::computeAggregate(
   return 0;
 }
 
-bool CompositeEventGenerator::checkParameters(PubPkt* pkt,
-                                              PartialEvent* partialEvent,
-                                              set<CPUParameter*>& parameters) {
-  for (set<CPUParameter*>::iterator it = parameters.begin();
+bool CompositeEventGenerator::checkParameters(
+    PubPkt* pkt, PartialEvent& partialEvent, vector<CPUParameter>& parameters) {
+  for (vector<CPUParameter>::iterator it = parameters.begin();
        it != parameters.end(); ++it) {
     // cout << "Agg par" << endl;
-    if (!checkComplexParameter(pkt, partialEvent, *it, -1, AGG))
+    if (!checkComplexParameter(pkt, &partialEvent, &(*it), -1, AGG))
       return false;
   }
   return true;

--- a/TRex2-lib/src/Engine/CompositeEventGenerator.cc
+++ b/TRex2-lib/src/Engine/CompositeEventGenerator.cc
@@ -31,7 +31,7 @@ CompositeEventGenerator::~CompositeEventGenerator() { delete ceTemplate; }
 
 PubPkt* CompositeEventGenerator::generateCompositeEvent(
     PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedPkts,
     std::vector<std::vector<PubPkt*>>& receivedAggs,
     std::map<int, std::vector<CPUParameter>>& aggregateParameters) {
   int eventType = ceTemplate->getEventType();
@@ -43,21 +43,20 @@ PubPkt* CompositeEventGenerator::generateCompositeEvent(
     ValType valType = ceTemplate->getAttributeTree(i)->getValType();
     attributes[i].type = valType;
     if (valType == INT)
-      attributes[i].intVal = computeIntValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-          aggregateParameters, ceTemplate->getAttributeTree(i));
+      attributes[i].intVal =
+          computeIntValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                          aggregateParameters, ceTemplate->getAttributeTree(i));
     else if (valType == FLOAT)
       attributes[i].floatVal = computeFloatValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
+          partialEvent, aggregates, receivedPkts, receivedAggs,
           aggregateParameters, ceTemplate->getAttributeTree(i));
     else if (valType == BOOL)
       attributes[i].boolVal = computeBoolValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
+          partialEvent, aggregates, receivedPkts, receivedAggs,
           aggregateParameters, ceTemplate->getAttributeTree(i));
     else if (valType == STRING)
-      computeStringValue(partialEvent, aggregates, aggsSize, receivedPkts,
-                         receivedAggs, aggregateParameters,
-                         ceTemplate->getAttributeTree(i),
+      computeStringValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                         aggregateParameters, ceTemplate->getAttributeTree(i),
                          attributes[i].stringVal);
   }
   for (int i = 0; i < staticAttributesNum; i++) {
@@ -71,7 +70,7 @@ PubPkt* CompositeEventGenerator::generateCompositeEvent(
 
 inline int CompositeEventGenerator::computeIntValue(
     PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedPkts,
     std::vector<std::vector<PubPkt*>>& receivedAggs,
     std::map<int, std::vector<CPUParameter>>& aggregateParameters,
     OpTree* opTree) {
@@ -104,18 +103,18 @@ inline int CompositeEventGenerator::computeIntValue(
       else if (type == FLOAT)
         return pkt->getFloatAttributeVal(attrIndex);
     } else {
-      return computeAggregate(index, partialEvent, aggregates, aggsSize,
-                              receivedPkts, receivedAggs, aggregateParameters);
+      return computeAggregate(index, partialEvent, aggregates, receivedPkts,
+                              receivedAggs, aggregateParameters);
     }
   } else {
     // Integer can only be obtained from integer:
     // assume this is ensured at rule deployment time
-    int leftValue = computeIntValue(
-        partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-        aggregateParameters, opTree->getLeftSubtree());
-    int rightValue = computeIntValue(
-        partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-        aggregateParameters, opTree->getRightSubtree());
+    int leftValue =
+        computeIntValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                        aggregateParameters, opTree->getLeftSubtree());
+    int rightValue =
+        computeIntValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                        aggregateParameters, opTree->getRightSubtree());
     OpTreeOperation op = opTree->getOp();
     cout << "CPU not leaf " << leftValue << "; " << rightValue << ". OP " << op
          << endl;
@@ -133,7 +132,7 @@ inline int CompositeEventGenerator::computeIntValue(
 
 inline float CompositeEventGenerator::computeFloatValue(
     PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedPkts,
     std::vector<std::vector<PubPkt*>>& receivedAggs,
     std::map<int, std::vector<CPUParameter>>& aggregateParameters,
     OpTree* opTree) {
@@ -167,30 +166,30 @@ inline float CompositeEventGenerator::computeFloatValue(
       else if (type == FLOAT)
         return pkt->getFloatAttributeVal(attrIndex);
     } else {
-      return computeAggregate(index, partialEvent, aggregates, aggsSize,
-                              receivedPkts, receivedAggs, aggregateParameters);
+      return computeAggregate(index, partialEvent, aggregates, receivedPkts,
+                              receivedAggs, aggregateParameters);
     }
   } else {
     // Floats can only be obtained from integer and float:
     // assume this is ensured at rule deployment time
     float leftValue;
     if (opTree->getLeftSubtree()->getValType() == INT)
-      leftValue = computeIntValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-          aggregateParameters, opTree->getLeftSubtree());
+      leftValue =
+          computeIntValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                          aggregateParameters, opTree->getLeftSubtree());
     else
-      leftValue = computeFloatValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-          aggregateParameters, opTree->getLeftSubtree());
+      leftValue = computeFloatValue(partialEvent, aggregates, receivedPkts,
+                                    receivedAggs, aggregateParameters,
+                                    opTree->getLeftSubtree());
     float rightValue;
     if (opTree->getRightSubtree()->getValType() == INT)
-      rightValue = computeIntValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-          aggregateParameters, opTree->getRightSubtree());
+      rightValue =
+          computeIntValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                          aggregateParameters, opTree->getRightSubtree());
     else
-      rightValue = computeFloatValue(
-          partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-          aggregateParameters, opTree->getRightSubtree());
+      rightValue = computeFloatValue(partialEvent, aggregates, receivedPkts,
+                                     receivedAggs, aggregateParameters,
+                                     opTree->getRightSubtree());
     OpTreeOperation op = opTree->getOp();
     if (op == ADD)
       return leftValue + rightValue;
@@ -206,7 +205,7 @@ inline float CompositeEventGenerator::computeFloatValue(
 
 inline bool CompositeEventGenerator::computeBoolValue(
     PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedPkts,
     std::vector<std::vector<PubPkt*>>& receivedAggs,
     std::map<int, std::vector<CPUParameter>>& aggregateParameters,
     OpTree* opTree) {
@@ -243,12 +242,12 @@ inline bool CompositeEventGenerator::computeBoolValue(
   } else {
     // Booleans can only be obtained from booleans:
     // assume this is ensured at rule deployment time
-    bool leftValue = computeBoolValue(
-        partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-        aggregateParameters, opTree->getLeftSubtree());
-    bool rightValue = computeBoolValue(
-        partialEvent, aggregates, aggsSize, receivedPkts, receivedAggs,
-        aggregateParameters, opTree->getRightSubtree());
+    bool leftValue =
+        computeBoolValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                         aggregateParameters, opTree->getLeftSubtree());
+    bool rightValue =
+        computeBoolValue(partialEvent, aggregates, receivedPkts, receivedAggs,
+                         aggregateParameters, opTree->getRightSubtree());
     OpTreeOperation op = opTree->getOp();
     if (op == AND)
       return leftValue && rightValue;
@@ -260,7 +259,7 @@ inline bool CompositeEventGenerator::computeBoolValue(
 
 inline void CompositeEventGenerator::computeStringValue(
     PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedPkts,
     std::vector<std::vector<PubPkt*>>& receivedAggs,
     std::map<int, std::vector<CPUParameter>>& aggregateParameters,
     OpTree* opTree, char* result) {
@@ -292,7 +291,7 @@ inline void CompositeEventGenerator::computeStringValue(
 
 inline float CompositeEventGenerator::computeAggregate(
     int index, PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-    std::vector<int>& aggsSize, std::vector<std::vector<PubPkt*>>& receivedPkts,
+    std::vector<std::vector<PubPkt*>>& receivedPkts,
     std::vector<std::vector<PubPkt*>>& receivedAggs,
     std::map<int, std::vector<CPUParameter>>& aggregateParameters) {
   Aggregate& agg = aggregates[index];

--- a/TRex2-lib/src/Engine/CompositeEventGenerator.h
+++ b/TRex2-lib/src/Engine/CompositeEventGenerator.h
@@ -51,10 +51,29 @@ public:
   /**
    * Creates a new composite event starting from the stored template and
    * from the set of events given as input parameter.
+   *
+   * @deprecated use
+   *     `PubPkt* generateCompositeEvent(
+   *          PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+   *          std::vector<std::vector<PubPkt*>>& receivedPkts,
+   *          std::vector<std::vector<PubPkt*>>& receivedAggs,
+   *          std::map<int, std::vector<CPUParameter>>& aggregateParameters);`
    */
   PubPkt* generateCompositeEvent(
       PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
       std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters) {
+    return generateCompositeEvent(partialEvent, aggregates, receivedPkts,
+                                  receivedAggs, aggregateParameters);
+  }
+  /**
+   * Creates a new composite event starting from the stored template and
+   * from the set of events given as input parameter.
+   */
+  PubPkt* generateCompositeEvent(
+      PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
       std::vector<std::vector<PubPkt*>>& receivedPkts,
       std::vector<std::vector<PubPkt*>>& receivedAggs,
       std::map<int, std::vector<CPUParameter>>& aggregateParameters);
@@ -75,7 +94,6 @@ private:
    */
   inline int computeIntValue(
       PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-      std::vector<int>& aggsSize,
       std::vector<std::vector<PubPkt*>>& receivedPkts,
       std::vector<std::vector<PubPkt*>>& receivedAggs,
       std::map<int, std::vector<CPUParameter>>& aggregateParameters,
@@ -87,7 +105,6 @@ private:
    */
   inline float computeFloatValue(
       PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-      std::vector<int>& aggsSize,
       std::vector<std::vector<PubPkt*>>& receivedPkts,
       std::vector<std::vector<PubPkt*>>& receivedAggs,
       std::map<int, std::vector<CPUParameter>>& aggregateParameters,
@@ -99,7 +116,6 @@ private:
    */
   inline bool computeBoolValue(
       PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-      std::vector<int>& aggsSize,
       std::vector<std::vector<PubPkt*>>& receivedPkts,
       std::vector<std::vector<PubPkt*>>& receivedAggs,
       std::map<int, std::vector<CPUParameter>>& aggregateParameters,
@@ -111,7 +127,6 @@ private:
    */
   inline void computeStringValue(
       PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-      std::vector<int>& aggsSize,
       std::vector<std::vector<PubPkt*>>& receivedPkts,
       std::vector<std::vector<PubPkt*>>& receivedAggs,
       std::map<int, std::vector<CPUParameter>>& aggregateParameters,
@@ -125,7 +140,6 @@ private:
    */
   inline float computeAggregate(
       int index, PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
-      std::vector<int>& aggsSize,
       std::vector<std::vector<PubPkt*>>& receivedPkts,
       std::vector<std::vector<PubPkt*>>& receivedAggs,
       std::map<int, std::vector<CPUParameter>>& aggregateParameters);

--- a/TRex2-lib/src/Engine/CompositeEventGenerator.h
+++ b/TRex2-lib/src/Engine/CompositeEventGenerator.h
@@ -53,11 +53,11 @@ public:
    * from the set of events given as input parameter.
    */
   PubPkt* generateCompositeEvent(
-      PartialEvent* partialEvent, std::map<int, Aggregate*>& aggregates,
-      int aggsSize[MAX_RULE_FIELDS],
-      std::map<int, std::vector<PubPkt*>>& receivedPkts,
-      std::map<int, std::vector<PubPkt*>>& receivedAggs,
-      std::map<int, std::set<CPUParameter*>>& aggregateParameters);
+      PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+      std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters);
 
 private:
   int loccount;
@@ -74,11 +74,11 @@ private:
    * Requires the type to be INT
    */
   inline int computeIntValue(
-      PartialEvent* partialEvent, std::map<int, Aggregate*>& aggregates,
-      int aggsSize[MAX_RULE_FIELDS],
-      std::map<int, std::vector<PubPkt*>>& receivedPkts,
-      std::map<int, std::vector<PubPkt*>>& receivedAggs,
-      std::map<int, std::set<CPUParameter*>>& aggregateParameters,
+      PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+      std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters,
       OpTree* opTree);
 
   /**
@@ -86,11 +86,11 @@ private:
    * Requires the type to be FLOAT
    */
   inline float computeFloatValue(
-      PartialEvent* partialEvent, std::map<int, Aggregate*>& aggregates,
-      int aggsSize[MAX_RULE_FIELDS],
-      std::map<int, std::vector<PubPkt*>>& receivedPkts,
-      std::map<int, std::vector<PubPkt*>>& receivedAggs,
-      std::map<int, std::set<CPUParameter*>>& aggregateParameters,
+      PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+      std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters,
       OpTree* opTree);
 
   /**
@@ -98,11 +98,11 @@ private:
    * Requires the type to be BOOL
    */
   inline bool computeBoolValue(
-      PartialEvent* partialEvent, std::map<int, Aggregate*>& aggregates,
-      int aggsSize[MAX_RULE_FIELDS],
-      std::map<int, std::vector<PubPkt*>>& receivedPkts,
-      std::map<int, std::vector<PubPkt*>>& receivedAggs,
-      std::map<int, std::set<CPUParameter*>>& aggregateParameters,
+      PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+      std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters,
       OpTree* opTree);
 
   /**
@@ -110,11 +110,11 @@ private:
    * Requires the type to be STRING
    */
   inline void computeStringValue(
-      PartialEvent* partialEvent, std::map<int, Aggregate*>& aggregates,
-      int aggsSize[MAX_RULE_FIELDS],
-      std::map<int, std::vector<PubPkt*>>& receivedPkts,
-      std::map<int, std::vector<PubPkt*>>& receivedAggs,
-      std::map<int, std::set<CPUParameter*>>& aggregateParameters,
+      PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+      std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters,
       OpTree* opTree, char* result);
 
   /**
@@ -124,17 +124,17 @@ private:
    * for computing the aggregate.
    */
   inline float computeAggregate(
-      int index, PartialEvent* partialEvent,
-      std::map<int, Aggregate*>& aggregates, int aggsSize[MAX_RULE_FIELDS],
-      std::map<int, std::vector<PubPkt*>>& receivedPkts,
-      std::map<int, std::vector<PubPkt*>>& receivedAggs,
-      std::map<int, std::set<CPUParameter*>>& aggregateParameters);
+      int index, PartialEvent& partialEvent, std::vector<Aggregate>& aggregates,
+      std::vector<int>& aggsSize,
+      std::vector<std::vector<PubPkt*>>& receivedPkts,
+      std::vector<std::vector<PubPkt*>>& receivedAggs,
+      std::map<int, std::vector<CPUParameter>>& aggregateParameters);
 
   /**
    * Returns true if the packet satisfies all parameters, and false otherwise
    */
-  inline bool checkParameters(PubPkt* pkt, PartialEvent* partialEvent,
-                              std::set<CPUParameter*>& parameters);
+  inline bool checkParameters(PubPkt* pkt, PartialEvent& partialEvent,
+                              std::vector<CPUParameter>& parameters);
 };
 
 #endif /* COMPOSITEEVENTGENERATOR_H_ */

--- a/TRex2-lib/src/Engine/Stack.cc
+++ b/TRex2-lib/src/Engine/Stack.cc
@@ -22,15 +22,45 @@
 
 using namespace std;
 
-Stack::Stack(int refersTo, TimeMs win, CompKind kind) {
-  this->refersTo = refersTo;
-  this->kind = kind;
-  this->win = win;
-  lookBackTo = new set<int>;
-  linkedNegations = new set<int>;
+Stack::Stack(int refersTo, TimeMs win, CompKind kind)
+    : refersTo(refersTo),
+      win(win),
+      kind(kind),
+      lookBackTo(new set<int>),
+      linkedNegations(new set<int>) {}
+
+Stack::Stack(const Stack& other)
+    : refersTo(other.refersTo),
+      win(other.win),
+      kind(other.kind),
+      lookBackTo(new set<int>(*other.lookBackTo)),
+      linkedNegations(new set<int>(*other.lookBackTo)) {}
+
+Stack::Stack(Stack&& other)
+    : refersTo(other.refersTo),
+      win(other.win),
+      kind(other.kind),
+      lookBackTo(),
+      linkedNegations() {
+  std::swap(lookBackTo, other.lookBackTo);
+  std::swap(linkedNegations, other.linkedNegations);
+}
+
+Stack& Stack::operator=(Stack other) {
+  refersTo = other.refersTo;
+  win = other.win;
+  kind = other.kind;
+  std::swap(lookBackTo, other.lookBackTo);
+  std::swap(linkedNegations, other.linkedNegations);
+
+  return *this;
 }
 
 Stack::~Stack() {
-  delete lookBackTo;
-  delete linkedNegations;
+  if (lookBackTo != NULL) {
+    delete lookBackTo;
+  }
+  if (linkedNegations != NULL) {
+    delete linkedNegations;
+  }
 }

--- a/TRex2-lib/src/Engine/Stack.cc
+++ b/TRex2-lib/src/Engine/Stack.cc
@@ -26,41 +26,5 @@ Stack::Stack(int refersTo, TimeMs win, CompKind kind)
     : refersTo(refersTo),
       win(win),
       kind(kind),
-      lookBackTo(new set<int>),
-      linkedNegations(new set<int>) {}
-
-Stack::Stack(const Stack& other)
-    : refersTo(other.refersTo),
-      win(other.win),
-      kind(other.kind),
-      lookBackTo(new set<int>(*other.lookBackTo)),
-      linkedNegations(new set<int>(*other.lookBackTo)) {}
-
-Stack::Stack(Stack&& other)
-    : refersTo(other.refersTo),
-      win(other.win),
-      kind(other.kind),
       lookBackTo(),
-      linkedNegations() {
-  std::swap(lookBackTo, other.lookBackTo);
-  std::swap(linkedNegations, other.linkedNegations);
-}
-
-Stack& Stack::operator=(Stack other) {
-  refersTo = other.refersTo;
-  win = other.win;
-  kind = other.kind;
-  std::swap(lookBackTo, other.lookBackTo);
-  std::swap(linkedNegations, other.linkedNegations);
-
-  return *this;
-}
-
-Stack::~Stack() {
-  if (lookBackTo != NULL) {
-    delete lookBackTo;
-  }
-  if (linkedNegations != NULL) {
-    delete linkedNegations;
-  }
-}
+      linkedNegations() {}

--- a/TRex2-lib/src/Engine/Stack.h
+++ b/TRex2-lib/src/Engine/Stack.h
@@ -31,6 +31,12 @@ public:
    */
   Stack(int refersTo, TimeMs window, CompKind kind);
 
+  Stack(const Stack& other);
+
+  Stack(Stack&& other);
+
+  Stack& operator=(Stack other);
+
   /**
    * Destructor
    */

--- a/TRex2-lib/src/Engine/Stack.h
+++ b/TRex2-lib/src/Engine/Stack.h
@@ -31,16 +31,10 @@ public:
    */
   Stack(int refersTo, TimeMs window, CompKind kind);
 
-  Stack(const Stack& other);
-
-  Stack(Stack&& other);
-
-  Stack& operator=(Stack other);
-
   /**
    * Destructor
    */
-  virtual ~Stack();
+  virtual ~Stack(){};
 
   CompKind getKind() const { return kind; }
 
@@ -51,22 +45,22 @@ public:
   /**
    * Add a new referred Stack
    */
-  void addLookBackTo(int reference) { lookBackTo->insert(reference); }
+  void addLookBackTo(int reference) { lookBackTo.insert(reference); }
 
   /**
    * Get referred Stacks
    */
-  std::set<int>* getLookBackTo() { return lookBackTo; }
+  std::set<int>& getLookBackTo() { return lookBackTo; }
 
   /**
    * Add a new referred Negation
    */
-  void addLinkedNegation(int reference) { linkedNegations->insert(reference); }
+  void addLinkedNegation(int reference) { linkedNegations.insert(reference); }
 
   /**
    * Get referred Negations
    */
-  std::set<int>* getLinkedNegations() { return linkedNegations; }
+  std::set<int>& getLinkedNegations() { return linkedNegations; }
 
 private:
   // The stack it refers to
@@ -76,9 +70,9 @@ private:
   // The kind of composition
   CompKind kind;
   // Referred stacks
-  std::set<int>* lookBackTo;
+  std::set<int> lookBackTo;
   // Referred negations
-  std::set<int>* linkedNegations;
+  std::set<int> linkedNegations;
 };
 
 #endif

--- a/TRex2-lib/src/Engine/StacksRule.cc
+++ b/TRex2-lib/src/Engine/StacksRule.cc
@@ -86,85 +86,57 @@ StacksRule::StacksRule(RulePkt* pkt) {
                         pkt->getComplexParameter(i).vtype);
   }
   // Initialize the set of consuming indexes
-  set<int> cons = pkt->getConsuming();
-  for (set<int>::iterator it = cons.begin(); it != cons.end(); ++it) {
-    int consumedIndex = *it;
-    consumingIndexes.insert(consumedIndex);
-  }
+  consumingIndexes = pkt->getConsuming();
 }
 
 StacksRule::~StacksRule() {
   // Deletes stored messages used
-  for (map<int, vector<PubPkt*>>::iterator it = receivedPkts.begin();
-       it != receivedPkts.end(); ++it) {
-    vector<PubPkt*> temp = it->second;
-    for (vector<PubPkt*>::iterator it2 = temp.begin(); it2 != temp.end();
-         ++it2) {
-      PubPkt* pkt = *it2;
-      if (pkt->decRefCount())
+  for (const auto& receivedPkt : receivedPkts) {
+    for (const auto& pkt : receivedPkt.second) {
+      if (pkt->decRefCount()) {
         delete pkt;
+      }
     }
   }
-  for (map<int, vector<PubPkt*>>::iterator it = receivedAggs.begin();
-       it != receivedAggs.end(); ++it) {
-    vector<PubPkt*> temp = it->second;
-    for (vector<PubPkt*>::iterator it2 = temp.begin(); it2 != temp.end();
-         ++it2) {
-      PubPkt* pkt = *it2;
-      if (pkt->decRefCount())
+  for (const auto& receivedAgg : receivedAggs) {
+    for (const auto& pkt : receivedAgg.second) {
+      if (pkt->decRefCount()) {
         delete pkt;
+      }
     }
   }
-  for (map<int, vector<PubPkt*>>::iterator it = receivedNegs.begin();
-       it != receivedNegs.end(); ++it) {
-    vector<PubPkt*> temp = it->second;
-    for (vector<PubPkt*>::iterator it2 = temp.begin(); it2 != temp.end();
-         ++it2) {
-      PubPkt* pkt = *it2;
-      if (pkt->decRefCount())
+  for (const auto& receivedNeg : receivedNegs) {
+    for (const auto& pkt : receivedNeg.second) {
+      if (pkt->decRefCount()) {
         delete pkt;
+      }
     }
   }
 
   // frees heap memory
-  for (map<int, Stack*>::iterator it = stacks.begin(); it != stacks.end();
-       ++it) {
-    delete it->second;
+  for (const auto& stack : stacks) {
+    delete stack.second;
   }
-  for (set<Parameter*>::iterator it = endStackParameters.begin();
-       it != endStackParameters.end(); ++it) {
-    Parameter* par = *it;
+  for (const auto& par : endStackParameters) {
     delete par;
   }
 
-  for (map<int, set<CPUParameter*>>::iterator it =
-           branchStackComplexParameters.begin();
-       it != branchStackComplexParameters.end(); ++it) {
-    set<CPUParameter*> temp = it->second;
-    for (set<CPUParameter*>::iterator it2 = temp.begin(); it2 != temp.end();
-         ++it2) {
-      CPUParameter* par = *it2;
+  for (const auto& branchStackComplexParameter : branchStackComplexParameters) {
+    for (const auto& par : branchStackComplexParameter.second) {
       delete par;
     }
   }
 
-  for (map<int, set<CPUParameter*>>::iterator it =
-           aggregateComplexParameters.begin();
-       it != aggregateComplexParameters.end(); ++it) {
-    set<CPUParameter*> temp = it->second;
-    for (set<CPUParameter*>::iterator it2 = temp.begin(); it2 != temp.end();
-         ++it2) {
-      CPUParameter* par = *it2;
+  for (const auto& aggregateComplexParameter : aggregateComplexParameters) {
+    for (const auto& par : aggregateComplexParameter.second) {
       delete par;
     }
   }
-  for (map<int, Aggregate*>::iterator it = aggregates.begin();
-       it != aggregates.end(); ++it) {
-    delete it->second;
+  for (const auto& aggregate : aggregates) {
+    delete aggregate.second;
   }
-  for (map<int, Negation*>::iterator it = negations.begin();
-       it != negations.end(); ++it) {
-    delete it->second;
+  for (const auto& negation : negations) {
+    delete negation.second;
   }
   delete eventGenerator;
 }
@@ -200,8 +172,9 @@ void StacksRule::startComputation(PubPkt* pkt, set<PubPkt*>& results) {
   deletePartialEvents(partialResults);
   // Removes the terminator from the last stack
   receivedPkts[0].clear();
-  if (pkt->decRefCount())
+  if (pkt->decRefCount()) {
     delete pkt;
+  }
   stacksSize[0] = 0;
 }
 
@@ -209,33 +182,29 @@ void StacksRule::processPkt(PubPkt* pkt, MatchingHandler* mh,
                             set<PubPkt*>& results, int index) {
   map<int, set<int>>::iterator aggIt = mh->matchingAggregates.find(index);
   if (aggIt != mh->matchingAggregates.end()) {
-    for (set<int>::iterator it = aggIt->second.begin();
-         it != aggIt->second.end(); ++it) {
-      int aggIndex = *it;
+    for (const auto& aggIndex : aggIt->second) {
       addToAggregateStack(pkt, aggIndex);
     }
   }
   map<int, set<int>>::iterator negIt = mh->matchingNegations.find(index);
   if (negIt != mh->matchingNegations.end()) {
-    for (set<int>::iterator it = negIt->second.begin();
-         it != negIt->second.end(); ++it) {
-      int negIndex = *it;
+    for (const auto& negIndex : negIt->second) {
       addToNegationStack(pkt, negIndex);
     }
   }
   map<int, set<int>>::iterator stateIt = mh->matchingStates.find(index);
   if (stateIt != mh->matchingStates.end()) {
     bool lastStack = false;
-    for (set<int>::iterator it = stateIt->second.begin();
-         it != stateIt->second.end(); ++it) {
-      int stateIndex = *it;
+    for (const auto& stateIndex : stateIt->second) {
       if (stateIndex != 0) {
         addToStack(pkt, stateIndex);
-      } else
+      } else {
         lastStack = true;
+      }
     }
-    if (lastStack)
+    if (lastStack) {
       startComputation(pkt, results);
+    }
   }
 }
 
@@ -265,8 +234,9 @@ void StacksRule::addParameter(int index1, char* name1, int index2, char* name2,
   strcpy(tmp->name2, name2);
   if (type == STATE) {
     if (pkt->isInTheSameSequence(index1, index2) /*&& index2>0*/) {
-    } else
+    } else {
       endStackParameters.insert(tmp);
+    }
   }
 }
 
@@ -305,10 +275,11 @@ void StacksRule::addNegation(int eventType, Constraint constraints[],
   negations[negsNum]->upperId = highIndex;
   vector<PubPkt*> emptyVec;
   receivedNegs.insert(make_pair(negsNum, emptyVec));
-  if (lowIndex < 0)
+  if (lowIndex < 0) {
     stacks[highIndex]->addLinkedNegation(negsNum);
-  else
+  } else {
     stacks[lowIndex]->addLinkedNegation(negsNum);
+  }
   negsNum++;
 }
 
@@ -333,25 +304,30 @@ void StacksRule::getWinEvents(list<PartialEvent*>* results, int index,
                               TimeMs tsUp, CompKind mode,
                               PartialEvent* partialEvent) {
   bool useComplexParameters = false;
-  if (stacksSize[index] == 0)
+  if (stacksSize[index] == 0) {
     return;
+  }
   // Extracts the minimum and maximum element to process.
   // Returns immediately if they cannot be found.
   TimeMs minTimeStamp = tsUp - stacks[index]->getWindow();
   int index1 = getFirstValidElement(receivedPkts[index], stacksSize[index],
                                     minTimeStamp);
-  if (index1 < 0)
+  if (index1 < 0) {
     return;
-  if (receivedPkts[index][index1]->getTimeStamp() >= tsUp)
+  }
+  if (receivedPkts[index][index1]->getTimeStamp() >= tsUp) {
     return;
+  }
   int index2 =
       getLastValidElement(receivedPkts[index], stacksSize[index], tsUp, index1);
-  if (index2 < 0)
+  if (index2 < 0) {
     index2 = index1;
+  }
   map<int, set<CPUParameter*>>::iterator itComplex =
       branchStackComplexParameters.find(index);
-  if (itComplex != branchStackComplexParameters.end())
+  if (itComplex != branchStackComplexParameters.end()) {
     useComplexParameters = true;
+  }
 
   // Computes the indexes for processing
   int count = 0;
@@ -365,9 +341,10 @@ void StacksRule::getWinEvents(list<PartialEvent*>* results, int index,
   while (true) {
     bool usable = true;
     PubPkt* tmpPkt = receivedPkts[index][index1 + count];
-    if (useComplexParameters)
+    if (useComplexParameters) {
       usable = checkParameters(tmpPkt, partialEvent, itComplex->second, index,
                                STATE);
+    }
     if (usable) {
       PartialEvent* newPartialEvent = new PartialEvent;
       memcpy(newPartialEvent->indexes, partialEvent->indexes,
@@ -375,23 +352,19 @@ void StacksRule::getWinEvents(list<PartialEvent*>* results, int index,
       newPartialEvent->indexes[index] = tmpPkt;
       // Check negations
       bool invalidatedByNegations = false;
-      set<int>* negation = stacks[index]->getLinkedNegations();
-      if (!negation->empty()) {
-        for (set<int>::iterator it = negation->begin(); it != negation->end();
-             ++it) {
-          int neg = *it;
-          if (checkNegation(neg, newPartialEvent)) {
-            invalidatedByNegations = true;
-            break;
-          }
+      for (const auto& neg : *(stacks[index]->getLinkedNegations())) {
+        if (checkNegation(neg, newPartialEvent)) {
+          invalidatedByNegations = true;
+          break;
         }
       }
       // If it is not invalidated by events, add the new partial event to
       // results, otherwise delete it
       if (!invalidatedByNegations) {
         results->push_back(newPartialEvent);
-        if (mode == LAST_WITHIN || mode == FIRST_WITHIN)
+        if (mode == LAST_WITHIN || mode == FIRST_WITHIN) {
           break;
+        }
       } else {
         delete newPartialEvent;
       }
@@ -400,12 +373,14 @@ void StacksRule::getWinEvents(list<PartialEvent*>* results, int index,
     // and check termination condition
     if (mode == LAST_WITHIN) {
       count--;
-      if (count < endCount)
+      if (count < endCount) {
         return;
+      }
     } else {
       count++;
-      if (count > endCount)
+      if (count > endCount) {
         return;
+      }
     }
   }
 }
@@ -413,8 +388,9 @@ void StacksRule::getWinEvents(list<PartialEvent*>* results, int index,
 bool StacksRule::checkNegation(int negIndex, PartialEvent* partialResult) {
   Negation* neg = negations[negIndex];
   // No negations: return false
-  if (negsSize[negIndex] == 0)
+  if (negsSize[negIndex] == 0) {
     return false;
+  }
   // Extracts timestamps and indexes
   TimeMs maxTS = partialResult->indexes[neg->upperId]->getTimeStamp();
   TimeMs minTS;
@@ -429,11 +405,13 @@ bool StacksRule::checkNegation(int negIndex, PartialEvent* partialResult) {
   // con TRex nel test Rain.
   // if (receivedNegs[negIndex][0]->getTimeStamp()<=maxTS &&
   // receivedNegs[negIndex][0]->getTimeStamp()>=minTS) return true;
-  if (index1 < 0)
+  if (index1 < 0) {
     return false;
+  }
   // maxTS and minTS negation events are not valid; Jan 2015
-  if (receivedNegs[negIndex][index1]->getTimeStamp() >= maxTS)
+  if (receivedNegs[negIndex][index1]->getTimeStamp() >= maxTS) {
     return false;
+  }
   int index2 = getLastValidElement(receivedNegs[negIndex], negsSize[negIndex],
                                    maxTS, index1);
   if (index2 < 0)
@@ -441,16 +419,18 @@ bool StacksRule::checkNegation(int negIndex, PartialEvent* partialResult) {
 
   map<int, set<CPUParameter*>>::iterator itComplex =
       negationComplexParameters.find(negIndex);
-  if (itComplex == negationComplexParameters.end())
+  if (itComplex == negationComplexParameters.end()) {
     return true;
+  }
   // Iterates over all negations and over all parameters.
   // If a negation can be found that satisfies all parameters,
   // then return true, otherwise return false
   for (int count = 0; count <= index2 - index1; count++) {
     PubPkt* tmpPkt = receivedNegs[negIndex].at(index1 + count);
     if (checkParameters(tmpPkt, partialResult, itComplex->second, negIndex,
-                        NEG))
+                        NEG)) {
       return true;
+    }
   }
   return false;
 }
@@ -462,25 +442,18 @@ list<PartialEvent*>* StacksRule::getPartialResults(PubPkt* pkt) {
   last->indexes[0] = pkt;
   prevEvents->push_back(last);
   // Checks negations on the first state
-  set<int>* negation = stacks[0]->getLinkedNegations();
-  if (!negation->empty()) {
-    for (set<int>::iterator it = negation->begin(); it != negation->end();
-         ++it) {
-      int neg = *it;
-      if (checkNegation(neg, last)) {
-        delete last;
-        delete prevEvents;
-        return currentEvents;
-      }
+  for (const auto& neg : *(stacks[0]->getLinkedNegations())) {
+    if (checkNegation(neg, last)) {
+      delete last;
+      delete prevEvents;
+      return currentEvents;
     }
   }
   // Iterates over all states
   for (int state = 1; state < stacksNum; state++) {
     Stack* stack = stacks[state];
     // Iterates over all previously generated events
-    for (list<PartialEvent*>::iterator listIt = prevEvents->begin();
-         listIt != prevEvents->end(); ++listIt) {
-      PartialEvent* event = *listIt;
+    for (const auto& event : *prevEvents) {
       // Extract events for next iteration
       int refState = referenceState[state];
       TimeMs maxTimeStamp = event->indexes[refState]->getTimeStamp();
@@ -488,17 +461,16 @@ list<PartialEvent*>* StacksRule::getPartialResults(PubPkt* pkt) {
       getWinEvents(currentEvents, state, maxTimeStamp, kind, event);
     }
     // Swaps current and previous results and deletes previous ones
-    for (list<PartialEvent*>::iterator it = prevEvents->begin();
-         it != prevEvents->end(); ++it) {
-      PartialEvent* pe = *it;
+    for (const auto& pe : *prevEvents) {
       delete pe;
     }
     prevEvents->clear();
     list<PartialEvent*>* temp = prevEvents;
     prevEvents = currentEvents;
     currentEvents = temp;
-    if (prevEvents->empty())
+    if (prevEvents->empty()) {
       break;
+    }
   }
   delete currentEvents;
   return prevEvents;
@@ -510,12 +482,15 @@ bool StacksRule::checkParameter(PubPkt* pkt, PartialEvent* partialEvent,
   PubPkt* receivedPkt = partialEvent->indexes[indexOfReferenceEvent];
   ValType type1, type2;
   int index1, index2;
-  if (!receivedPkt->getAttributeIndexAndType(parameter->name2, index2, type2))
+  if (!receivedPkt->getAttributeIndexAndType(parameter->name2, index2, type2)) {
     return false;
-  if (!pkt->getAttributeIndexAndType(parameter->name1, index1, type1))
+  }
+  if (!pkt->getAttributeIndexAndType(parameter->name1, index1, type1)) {
     return false;
-  if (type1 != type2)
+  }
+  if (type1 != type2) {
     return false;
+  }
   switch (type1) {
     case INT:
       return receivedPkt->getIntAttributeVal(index2) ==
@@ -540,43 +515,38 @@ bool StacksRule::checkParameter(PubPkt* pkt, PartialEvent* partialEvent,
 bool StacksRule::checkParameters(PubPkt* pkt, PartialEvent* partialEvent,
                                  set<CPUParameter*>& complexParameters,
                                  int index, StateType sType) {
-  for (set<CPUParameter*>::iterator it = complexParameters.begin();
-       it != complexParameters.end(); ++it) {
-    CPUParameter* par = *it;
-    if (!checkComplexParameter(pkt, partialEvent, par, index, sType))
+  for (const auto& par : complexParameters) {
+    if (!checkComplexParameter(pkt, partialEvent, par, index, sType)) {
       return false;
+    }
   }
   return true;
 }
 
 void StacksRule::removePartialEventsNotMatchingParameters(
     list<PartialEvent*>* partialEvents, set<Parameter*>& parameters) {
-  for (list<PartialEvent*>::iterator it = partialEvents->begin();
-       it != partialEvents->end();) {
+  for (auto it = partialEvents->begin(); it != partialEvents->end();) {
+    PartialEvent* partialEvent = *it;
     bool valid = true;
-    for (set<Parameter*>::iterator it2 = parameters.begin();
-         it2 != parameters.end(); ++it2) {
-      Parameter* par = *it2;
+    for (const auto& par : parameters) {
       int indexOfReferenceEvent = par->evIndex2;
-      PartialEvent* partialEvent = *it;
       PubPkt* receivedPkt = partialEvent->indexes[indexOfReferenceEvent];
       if (!checkParameter(receivedPkt, partialEvent, par)) {
         valid = false;
         break;
       }
     }
-    if (!valid)
+    if (!valid) {
       it = partialEvents->erase(it);
-    else
+    } else {
       ++it;
+    }
   }
 }
 
 void StacksRule::createComplexEvents(list<PartialEvent*>* partialEvents,
                                      set<PubPkt*>& results) {
-  for (list<PartialEvent*>::iterator it = partialEvents->begin();
-       it != partialEvents->end(); ++it) {
-    PartialEvent* pe = *it;
+  for (const auto& pe : *partialEvents) {
     PubPkt* genPkt = NULL;
     if (compositeEventId >= 0) {
       genPkt = new PubPkt(compositeEventId, NULL, 0);
@@ -591,28 +561,28 @@ void StacksRule::createComplexEvents(list<PartialEvent*>* partialEvents,
 }
 
 void StacksRule::removeConsumedEvent(list<PartialEvent*>* partialEvents) {
-  if (consumingIndexes.empty())
+  if (consumingIndexes.empty()) {
     return;
+  }
   for (int i = 1; i < stacksNum; i++) {
-    if (consumingIndexes.find(i) == consumingIndexes.end())
+    if (consumingIndexes.find(i) == consumingIndexes.end()) {
       continue;
+    }
     set<PubPkt*> pktsToRemove;
-    for (list<PartialEvent*>::iterator it = partialEvents->begin();
-         it != partialEvents->end(); ++it) {
-      PartialEvent* pe = *it;
+    for (const auto& pe : *partialEvents) {
       PubPkt* pkt = pe->indexes[i];
       if (pktsToRemove.find(pkt) == pktsToRemove.end()) {
         pktsToRemove.insert(pkt);
       }
     }
-    map<int, vector<PubPkt*>>::iterator mapIt = receivedPkts.find(i);
-    for (vector<PubPkt*>::iterator it = mapIt->second.begin();
-         it != mapIt->second.end();) {
+    std::vector<PubPkt*>& recPkts = receivedPkts[i];
+    for (auto it = recPkts.begin(); it != recPkts.end();) {
       PubPkt* pkt = *it;
       if (pktsToRemove.find(pkt) != pktsToRemove.end()) {
-        it = mapIt->second.erase(it);
-        if (pkt->decRefCount())
+        it = recPkts.erase(it);
+        if (pkt->decRefCount()) {
           delete pkt;
+        }
         stacksSize[i]--;
       } else {
         ++it;
@@ -622,9 +592,7 @@ void StacksRule::removeConsumedEvent(list<PartialEvent*>* partialEvents) {
 }
 
 void StacksRule::deletePartialEvents(list<PartialEvent*>* partialEvents) {
-  for (list<PartialEvent*>::iterator it = partialEvents->begin();
-       it != partialEvents->end(); ++it) {
-    PartialEvent* pe = *it;
+  for (const auto& pe : *partialEvents) {
     delete pe;
   }
   delete partialEvents;
@@ -633,8 +601,9 @@ void StacksRule::deletePartialEvents(list<PartialEvent*>* partialEvents) {
 void StacksRule::clearStacks() {
   for (int stack = 1; stack < stacksNum; stack++) {
     int refersToStack = stacks[stack]->getRefersTo();
-    if (stacksSize[refersToStack] == 0)
+    if (stacksSize[refersToStack] == 0) {
       continue;
+    }
     TimeMs minTS = receivedPkts[refersToStack][0]->getTimeStamp() -
                    stacks[stack]->getWindow();
     removeOldPacketsFromStack(minTS, stacksSize[stack], receivedPkts[stack]);
@@ -642,8 +611,9 @@ void StacksRule::clearStacks() {
   for (int negIndex = 0; negIndex < negsNum; negIndex++) {
     Negation* neg = negations[negIndex];
     int refersToStack = neg->upperId;
-    if (stacksSize[refersToStack] == 0)
+    if (stacksSize[refersToStack] == 0) {
       continue;
+    }
     TimeMs win;
     if (neg->lowerId < 0) {
       win = neg->lowerTime;
@@ -658,8 +628,9 @@ void StacksRule::clearStacks() {
   for (int aggIndex = 0; aggIndex < aggrsNum; aggIndex++) {
     Aggregate* agg = aggregates[aggIndex];
     int refersToStack = agg->upperId;
-    if (stacksSize[refersToStack] == 0)
+    if (stacksSize[refersToStack] == 0) {
       continue;
+    }
     TimeMs win = agg->lowerTime;
     if (win < 0) {
       int secondIndex = agg->lowerId;
@@ -673,16 +644,19 @@ void StacksRule::clearStacks() {
 
 void StacksRule::removeOldPacketsFromStack(TimeMs& minTS, int& parStacksSize,
                                            vector<PubPkt*>& parReceived) {
-  if (parStacksSize == 0)
+  if (parStacksSize == 0) {
     return;
+  }
   int newSize = deleteInvalidElements(parReceived, parStacksSize, minTS);
-  if (newSize == parStacksSize)
+  if (newSize == parStacksSize) {
     return;
+  }
   vector<PubPkt*>::iterator it = parReceived.begin();
   for (int count = 0; count < parStacksSize - newSize; count++) {
     PubPkt* pkt = *it;
-    if (pkt->decRefCount())
+    if (pkt->decRefCount()) {
       delete pkt;
+    }
     it = parReceived.erase(it);
   }
   parStacksSize = newSize;

--- a/TRex2-lib/src/Engine/StacksRule.h
+++ b/TRex2-lib/src/Engine/StacksRule.h
@@ -74,14 +74,34 @@ public:
   /**
    * Adds the given packet to stack 0 and starts
    * the computation of composite events.
+   *
+   * @deprecated use `std::set<PubPkt*> startComputation(PubPkt* pkt)`
    */
-  void startComputation(PubPkt* pkt, std::set<PubPkt*>& results);
+  void startComputation(PubPkt* pkt, std::set<PubPkt*>& results) {
+    results = startComputation(pkt);
+  }
+
+  /**
+   * Adds the given packet to stack 0 and starts
+   * the computation of composite events.
+   */
+  std::set<PubPkt*> startComputation(PubPkt* pkt);
+
+  /**
+   * Process pkt: used only for testing purpose
+   *
+   * @deprecated use `std::set<PubPkt*> processPkt(
+   *      PubPkt* pkt, MatchingHandler* mh, int index)`
+   */
+  void processPkt(PubPkt* pkt, MatchingHandler* mh, std::set<PubPkt*>& results,
+                  int index) {
+    results = processPkt(pkt, mh, index);
+  }
 
   /**
    * Process pkt: used only for testing purpose
    */
-  void processPkt(PubPkt* pkt, MatchingHandler* mh, std::set<PubPkt*>& results,
-                  int index);
+  std::set<PubPkt*> processPkt(PubPkt* pkt, MatchingHandler* mh, int index);
 
 private:
   // The id of the rule
@@ -166,9 +186,8 @@ private:
    * Returns the events that satisfy the stack window with the given from the
    * given time stamp
    */
-  inline void getWinEvents(std::list<PartialEvent>& partialEvents, int index,
-                           TimeMs tsUp, CompKind mode,
-                           PartialEvent& partialEvent);
+  std::list<PartialEvent> getWinEvents(int index, TimeMs tsUp, CompKind mode,
+                                       PartialEvent& partialEvent);
 
   /**
    * Return true for the presence of negation (according to parameters)
@@ -183,8 +202,7 @@ private:
   /**
    * Computes complex events and adds them to the results set
    */
-  inline void createComplexEvents(std::list<PartialEvent>& partialEvents,
-                                  std::set<PubPkt*>& results);
+  std::set<PubPkt*> createComplexEvents(std::list<PartialEvent>& partialEvents);
 
   /**
    * Removes events that have been consumed

--- a/TRex2-lib/src/Engine/StacksRule.h
+++ b/TRex2-lib/src/Engine/StacksRule.h
@@ -91,10 +91,11 @@ private:
   RulePkt* rulePkt;
 
   // Stacks in the rule (stack id -> data structure)
-  std::map<int, Stack*> stacks;
+  std::vector<Stack> stacks;
   // Set of parameters to check at the end
-  std::set<Parameter*> endStackParameters;
-  std::map<int, std::set<CPUParameter*>> branchStackComplexParameters;
+  std::vector<Parameter> endStackParameters;
+  // Parameters in the rule to check in the meantime
+  std::map<int, std::vector<CPUParameter>> branchStackComplexParameters;
   // Parameters in the rule to check in the meantime
   // (stack id -> data structure)
   // std::map<int, std::set<Parameter *> > branchStackParameters;
@@ -104,14 +105,14 @@ private:
 
   // Parameters in the rule to check in the meantime
   // (negation id -> data structure)
-  std::map<int, std::set<CPUParameter*>> negationComplexParameters;
+  std::map<int, std::vector<CPUParameter>> negationComplexParameters;
   // Parameters in the rule to check in the meantime
   // (aggregate id -> data structure)
-  std::map<int, std::set<CPUParameter*>> aggregateComplexParameters;
+  std::map<int, std::vector<CPUParameter>> aggregateComplexParameters;
   // Aggregate in the rule (aggregate id -> data structure)
-  std::map<int, Aggregate*> aggregates;
+  std::vector<Aggregate> aggregates;
   // Negations in the rule (negation id -> data structure)
-  std::map<int, Negation*> negations;
+  std::vector<Negation> negations;
   // Number of stacks in the rule
   int stacksNum;
   // Number of aggregates in the rule
@@ -120,21 +121,21 @@ private:
   int negsNum;
 
   // Stack id -> state it refers to in the rule
-  std::map<int, int> referenceState;
+  std::vector<int> referenceState;
 
   // Number of pkts stored for each stack in the rule
-  int stacksSize[MAX_RULE_FIELDS];
+  std::vector<int> stacksSize;
   // Number of pkts stored for each negation in the rule
-  int negsSize[MAX_RULE_FIELDS];
+  std::vector<int> negsSize;
   // Number of pkts stored for each aggregate in the sequence
-  int aggsSize[MAX_RULE_FIELDS];
+  std::vector<int> aggsSize;
 
   // Aggregate index -> set of all matching PubPkt
-  std::map<int, std::vector<PubPkt*>> receivedAggs;
+  std::vector<std::vector<PubPkt*>> receivedAggs;
   // Stack index -> set of all matching PubPkt
-  std::map<int, std::vector<PubPkt*>> receivedPkts;
+  std::vector<std::vector<PubPkt*>> receivedPkts;
   // Negation index -> set of all matching PubPkt
-  std::map<int, std::vector<PubPkt*>> receivedNegs;
+  std::vector<std::vector<PubPkt*>> receivedNegs;
 
   // Indexes of events in the consuming clause (set of stack ids)
   std::set<int> consumingIndexes;
@@ -222,7 +223,7 @@ private:
    * Returns true if all parameters are satisfied by the packet
    */
   inline bool checkParameters(PubPkt* pkt, PartialEvent* partialEvent,
-                              std::set<CPUParameter*>& complexParameters,
+                              std::vector<CPUParameter>& complexParameters,
                               int index, StateType sType);
 
   /**
@@ -230,7 +231,7 @@ private:
    */
   inline void removePartialEventsNotMatchingParameters(
       std::list<PartialEvent*>* partialEvents,
-      std::set<Parameter*>& parameters);
+      std::vector<Parameter>& parameters);
 
   /**
    * Remove packets invalidated by timing constraints.

--- a/TRex2-lib/src/Engine/StacksRule.h
+++ b/TRex2-lib/src/Engine/StacksRule.h
@@ -111,22 +111,9 @@ private:
   std::vector<Aggregate> aggregates;
   // Negations in the rule (negation id -> data structure)
   std::vector<Negation> negations;
-  // Number of stacks in the rule
-  int stacksNum;
-  // Number of aggregates in the rule
-  int aggrsNum;
-  // Number of negations in the rule
-  int negsNum;
 
   // Stack id -> state it refers to in the rule
   std::vector<int> referenceState;
-
-  // Number of pkts stored for each stack in the rule
-  std::vector<int> stacksSize;
-  // Number of pkts stored for each negation in the rule
-  std::vector<int> negsSize;
-  // Number of pkts stored for each aggregate in the sequence
-  std::vector<int> aggsSize;
 
   // Aggregate index -> set of all matching PubPkt
   std::vector<std::vector<PubPkt*>> receivedAggs;
@@ -146,7 +133,7 @@ private:
    * Adds the packet to the given stack (can be a normal stack, or a stack for
    * negations or aggregates)
    */
-  inline void parametricAddToStack(PubPkt* pkt, int& parStacksSize,
+  inline void parametricAddToStack(PubPkt* pkt,
                                    std::vector<PubPkt*>& parReceived);
 
   /**
@@ -236,7 +223,7 @@ private:
    * Removes all packets that are older than minTS from the given stack.
    * The stack can be a normal stack, or a stack for negations or aggregates.
    */
-  inline void removeOldPacketsFromStack(TimeMs& minTS, int& parStacksSize,
+  inline void removeOldPacketsFromStack(TimeMs& minTS,
                                         std::vector<PubPkt*>& parReceived);
 };
 

--- a/TRex2-lib/src/Engine/StacksRule.h
+++ b/TRex2-lib/src/Engine/StacksRule.h
@@ -31,8 +31,6 @@
 #include "Stack.h"
 #include <list>
 #include <map>
-#include <set>
-#include <bitset>
 #include <vector>
 
 /**
@@ -140,7 +138,7 @@ private:
   // Indexes of events in the consuming clause (set of stack ids)
   std::set<int> consumingIndexes;
   // Used to generate composite event attributes (if any)
-  CompositeEventGenerator* eventGenerator;
+  CompositeEventGenerator eventGenerator;
   // Used to generate a composite event id no attributes are defined
   int compositeEventId;
 
@@ -160,19 +158,20 @@ private:
   inline void addComplexParameter(Op pOperation, OpTree* lTree, OpTree* rTree,
                                   int lastIdx, StateType type, ValType vtype);
 
-  int computeIntValue(PubPkt* pkt, PartialEvent* partialEvent, OpTree* opTree,
+  int computeIntValue(PubPkt* pkt, PartialEvent& partialEvent, OpTree* opTree,
                       int index, bool isNeg);
 
   /**
    * Adds a new negation to negations map
    */
-  inline void addNegation(int eventType, Constraint* constraints, int constrLen,
-                          int lowIndex, TimeMs& lowTime, int highIndex);
+  inline void addNegation(int eventType, Constraint constraints[],
+                          int constrLen, int lowIndex, TimeMs& lowTime,
+                          int highIndex);
 
   /**
    * Adds a new aggregate to aggregates map
    */
-  inline void addAggregate(int eventType, Constraint* constraints,
+  inline void addAggregate(int eventType, Constraint constraints[],
                            int constrLen, int lowIndex, TimeMs& lowTime,
                            int highIndex, char* name, AggregateFun& fun);
 
@@ -180,41 +179,36 @@ private:
    * Returns the events that satisfy the stack window with the given from the
    * given time stamp
    */
-  inline void getWinEvents(std::list<PartialEvent*>* partialEvents, int index,
+  inline void getWinEvents(std::list<PartialEvent>& partialEvents, int index,
                            TimeMs tsUp, CompKind mode,
-                           PartialEvent* partialEvent);
+                           PartialEvent& partialEvent);
 
   /**
    * Return true for the presence of negation (according to parameters)
    */
-  inline bool checkNegation(int negIndex, PartialEvent* partialResult);
+  inline bool checkNegation(int negIndex, PartialEvent& partialResult);
 
   /**
    * Computes partial results and returns them as a list of PartialEvent.
    */
-  inline std::list<PartialEvent*>* getPartialResults(PubPkt* pkt);
+  inline std::list<PartialEvent> getPartialResults(PubPkt* pkt);
 
   /**
    * Computes complex events and adds them to the results set
    */
-  inline void createComplexEvents(std::list<PartialEvent*>* partialEvents,
+  inline void createComplexEvents(std::list<PartialEvent>& partialEvents,
                                   std::set<PubPkt*>& results);
 
   /**
    * Removes events that have been consumed
    */
-  inline void removeConsumedEvent(std::list<PartialEvent*>* partialEvents);
-
-  /**
-   * Deletes partial events
-   */
-  inline void deletePartialEvents(std::list<PartialEvent*>* partialEvents);
+  inline void removeConsumedEvent(std::list<PartialEvent>& partialEvents);
 
   /**
    * Returns true if the parameter is satisfied by the packet
    */
-  inline bool checkParameter(PubPkt* pkt, PartialEvent* partialEvent,
-                             Parameter* parameter);
+  inline bool checkParameter(PubPkt* pkt, PartialEvent& partialEvent,
+                             Parameter& parameter);
 
   // inline bool checkComplexParameter(PubPkt *pkt, PartialEvent
   // *partialEvent, CPUParameter *parameter, int index, bool isNeg);
@@ -222,7 +216,7 @@ private:
   /**
    * Returns true if all parameters are satisfied by the packet
    */
-  inline bool checkParameters(PubPkt* pkt, PartialEvent* partialEvent,
+  inline bool checkParameters(PubPkt* pkt, PartialEvent& partialEvent,
                               std::vector<CPUParameter>& complexParameters,
                               int index, StateType sType);
 
@@ -230,7 +224,7 @@ private:
    * Removes partial events that do not match parameters
    */
   inline void removePartialEventsNotMatchingParameters(
-      std::list<PartialEvent*>* partialEvents,
+      std::list<PartialEvent>& partialEvents,
       std::vector<Parameter>& parameters);
 
   /**

--- a/TRex2-lib/src/Engine/TRexEngine.cc
+++ b/TRex2-lib/src/Engine/TRexEngine.cc
@@ -73,7 +73,9 @@ void* processor(void* parShared) {
           }
         }
         if (lastState) {
-          s->stacksRule->find(i)->second->startComputation(s->pkt, s->result);
+          set<PubPkt*> newPackets =
+              s->stacksRule->find(i)->second->startComputation(s->pkt);
+          s->result.insert(newPackets.begin(), newPackets.end());
         }
       }
     }


### PR DESCRIPTION
Refactoring of stacks rule:
- using c++11 range loops
- returning collections by value instead of passing them as an output parameter
- changing collections type where appropriate
- simplifying code
- avoiding dynamically allocated memory as much as possible
- and always using brackets for clarity

It needs code review (@margara) and to be tested for soundness and performances!
